### PR TITLE
Added missing temporary directory flags to subroutines

### DIFF
--- a/py/palm_annot.py
+++ b/py/palm_annot.py
@@ -183,22 +183,25 @@ if Args.keeptmp == "yes":
 Exec(CmdLine)
 
 CmdLine = RepoDir + "py/palm_hmm_motif_search.py"
-CmdLine += "  --input " + AaFN
+CmdLine += " --input " + AaFN
 CmdLine += " --fev " + HMM_motif_fev
+CmdLine += " --tmpdir " + TmpDir
 if not Args.threads is None:
 	CmdLine += "  --threads %d" % Args.threads
 Exec(CmdLine)
 
 CmdLine = RepoDir + "py/palm_hmm_search.py"
-CmdLine += "  --input " + AaFN
-CmdLine += "  --fev " + HMM_pm_fev
+CmdLine += " --input " + AaFN
+CmdLine += " --fev " + HMM_pm_fev
+CmdLine += " --tmpdir " + TmpDir
 if not Args.threads is None:
 	CmdLine += "  --threads %d" % Args.threads
 Exec(CmdLine)
 
 CmdLine = RepoDir + "py/palm_diamond_motif_search.py"
-CmdLine += "  --input " + AaFN
+CmdLine += " --input " + AaFN
 CmdLine += " --fev " + Dmnd_fev
+CmdLine += " --tmpdir " + TmpDir
 if not Args.threads is None:
 	CmdLine += "  --threads %d" % Args.threads
 Exec(CmdLine)


### PR DESCRIPTION
The `--tmpdir` flag was not invoked for the following process calls:

1. palm_hmm_motif_search.py
2. palm_hmm_search.py
3. palm_diamond_motif_search.py

This caused these process to write to /tmp/ even when the user specified a custom temporary directory.